### PR TITLE
Fix remove cmd error

### DIFF
--- a/.guardian.yml
+++ b/.guardian.yml
@@ -1,0 +1,5 @@
+files: ./**/*.cr
+run: crystal build ./src/sharn.cr -p -t
+---
+files: ./shard.yml
+run: crystal deps

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Sharn (0.1.17)
+# Sharn (0.1.18)
 A command line program built on Crystal that adds new commands for the [Shards](https://github.com/crystal-lang/shards) dependency manager. It is inspired from [Yarn](https://yarnpkg.com), a package manager for Javascript.
 
 With Sharn, you don't have to write dependencies directly to your `shard.yml` file. Instead, you just have to type in the command and you're ready to go.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sharn add git/reponame
 
 2. Remove dependency/dependencies
 ```shell
-sharn remove depname1 depname2
+sharn rm depname1 depname2
 ```
 3. Specify version.
 ```shell
@@ -49,7 +49,7 @@ Subcommands:
   add
   inspect
   install (default)
-  remove
+  rm
   update
 
 Options:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: sharn
-version: 0.1.17
+version: 0.1.18
 authors:
 - Ned Palacios <npdoesmc@gmail.com>
 targets:

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -39,8 +39,9 @@ module SharnCLI
     class Add < Packager
       def run
         depType = options.dev? ? "development_dependencies" : "dependencies"
-
-        shardFile = File.read(options.debug? ? "./shard.test.yml" : "./shard.yml")
+        file = options.debug? ? "./shard.test.yml" : "./shard.yml"
+        puts "File detected: #{file}" if options.debug?
+        shardFile = File.read(file)
         shard = YAML.parse(shardFile)
         deps = YAML.parse(shard.as_h[depType].to_yaml).as_h || {} of String => Hash(String, String)
         newDeps = {} of String => Hash(String, String)

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -98,24 +98,24 @@ module SharnCLI
       end
     end
 
-    class Remove < Packager
-      def run
-        depType = options.dev? ? "development_dependencies" : "dependencies"
-        file = options.debug? ? "./shard.test.yml" : "./shard.yml"
-        puts "File detected: #{file}" if options.debug?
-        shardFile = File.read(file)
-        shard = YAML.parse(shardFile)
-        deps = YAML.parse(shard.as_h[depType].to_yaml).as_h || {} of String => Hash(String, String)
-        newDeps = {} of String => Hash(String, String)
+    # class Remove < Packager
+    #   def run
+    #     depType = options.dev? ? "development_dependencies" : "dependencies"
+    #     file = options.debug? ? "shard.test.yml" : "shard.yml"
+    #     puts "File detected: #{file}" if options.debug?
+    #     shardFile = File.read(file)
+    #     shard = YAML.parse(shardFile)
+    #     deps = YAML.parse(shard.as_h[depType].to_yaml).as_h || {} of String => Hash(String, String)
+    #     newDeps = {} of String => Hash(String, String)
+    #     output = YAML.dump(shard.as_h.merge({depType => newDeps})).gsub("---\n", "")
+    #     puts output if options.debug?
 
-        compiledDeps = {depType => newDeps}
-        output = YAML.dump(shard.as_h.merge(compiledDeps)).gsub("---\n", "")
-        File.write(options.debug? ? "./shard.test.yml" : "./shard.yml", output)
-        puts "\n"
+    #     File.write(options.debug? ? "./shard.test.yml" : "./shard.yml", output)
+    #     puts "\n"
 
-        Install.run unless options.debug? || options.noinstall?
-      end
-    end
+    #     Install.run unless options.debug? || options.noinstall?
+    #   end
+    # end
 
     class Inspect < Cli::Command
       class Options

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -55,9 +55,12 @@ module SharnCLI
             origin = match[4]
             owner = match[5]
             pkg_name = match[6]
-            branch = match[8] || "master"
+            branch = match[8] || nil
             path = "#{owner}/#{pkg_name}"
-            version = match[11] || "*"
+            version = match[11] || nil
+            pkg_detail = {platform => path, "branch" => branch, "version" => version}.compact
+
+            puts pkg_detail if options.debug?
 
             if owner == nil && pkg_name == nil
               platform = "git"
@@ -78,7 +81,7 @@ module SharnCLI
               puts "#{pkg_name} was already added to shards file."
             end
 
-            newDeps = newDeps.merge({pkg_name => {platform => path, "branch" => branch, "version" => version}}).compact
+            newDeps = newDeps.merge({pkg_name => pkg_detail}).compact
           end
         end
 

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -101,12 +101,13 @@ module SharnCLI
     class Remove < Packager
       def run
         depType = options.dev? ? "development_dependencies" : "dependencies"
-        shardFile = File.read(options.debug? ? "./shard.test.yml" : "./shard.yml")
+        file = options.debug? ? "./shard.test.yml" : "./shard.yml"
+        puts "File detected: #{file}" if options.debug?
+        shardFile = File.read(file)
         shard = YAML.parse(shardFile)
-        deps = YAML.parse(shard.as_h[depType].to_yaml).as_h
+        deps = YAML.parse(shard.as_h[depType].to_yaml).as_h || {} of String => Hash(String, String)
         newDeps = {} of String => Hash(String, String)
-        sleep(1)
-        newDeps = deps.reject(args.packages)
+
         compiledDeps = {depType => newDeps}
         output = YAML.dump(shard.as_h.merge(compiledDeps)).gsub("---\n", "")
         File.write(options.debug? ? "./shard.test.yml" : "./shard.yml", output)

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -144,13 +144,7 @@ module SharnCLI
     class Install < Cli::Command
       def run
         puts "Installing dependencies..."
-        output = IO::Memory.new
-
-        Process.run("shards", shell: true, output: output)
-        output.close
-        output.to_s
-
-        puts "\n"
+        Process.run("shards", shell: true)
         Inspect.run
       end
     end
@@ -158,13 +152,7 @@ module SharnCLI
     class Update < Cli::Command
       def run
         puts "Updating dependencies..."
-        output = IO::Memory.new
-
-        Process.run("shards update", shell: true, output: output)
-        output.close
-        output.to_s
-
-        puts "\n"
+        Process.run("shards update", shell: true)
         Inspect.run
       end
     end

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -102,11 +102,11 @@ module SharnCLI
         File.write(file, output)
 
         puts "\nDone."
+    class Rm < Packager
         Install.run unless options.debug? || options.noinstall?
       end
     end
 
-    # class Remove < Packager
     #   def run
     #     depType = options.dev? ? "development_dependencies" : "dependencies"
     #     file = options.debug? ? "shard.test.yml" : "shard.yml"

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -76,11 +76,11 @@ module SharnCLI
             if shard[depType].as_h.has_key?(pkg_name)
               puts "#{pkg_name} was already added to shards file."
             end
-          end
 
-          newDeps = newDeps.merge({pkg_name => {platform => path, "branch" => branch, "version" => version}}).compact
+            newDeps = newDeps.merge({pkg_name => {platform => path, "branch" => branch, "version" => version}}).compact
+          end
         end
-        # sleep(1)
+
         compiledDeps = {depType => deps.merge(newDeps)}
 
         if options.dev?

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -47,7 +47,7 @@ module SharnCLI
         newDeps = {} of String => Hash(String, String)
 
         args.packages.map do |pkgs|
-          regex = Regex.new("^((github|gitlab|bitbucket):)?((.+):)?([^/]+)\/([^#]+)(#(.+))?([^@]+)?(@(.+))$")
+          regex = Regex.new("^((github|gitlab|bitbucket):)?((.+):)?([^/]+)\/([^#]+)(#(.+))?([^@]+)?(@(.+))?$")
 
           if match = regex.match(pkgs).not_nil!.to_a
             platform = match[2] || "github"

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -32,6 +32,7 @@ module SharnCLI
         bool "--force", default: false
         bool "--debug", default: false
         bool "--noinstall", default: false
+        bool "--clean", default: false
         arg_array "packages"
       end
     end
@@ -86,7 +87,13 @@ module SharnCLI
         inserted = options.dev? ? shard.as_a : shard.as_h.merge(compiledDeps)
 
         output = YAML.dump(inserted).gsub("---\n", "").split("\n")
-        output = output.insert(2, "").insert(5, "")
+
+        if options.clean?
+          [2, 5].each do |idx|
+            output = output.insert(idx, " ")
+          end
+        end
+
         output = output.join("\n")
 
         File.write(file, output)

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -8,7 +8,7 @@ require "process"
 
 module SharnCLI
   class Sharn < Cli::Supercommand
-    version "0.1.17"
+    version "0.1.18"
     command "install", default: true
 
     # Just some crazy intro

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -83,18 +83,18 @@ module SharnCLI
 
         compiledDeps = {depType => deps.merge(newDeps)}
 
-        if options.dev?
-          inserted = shard.as_a
-          output = YAML.dump(inserted).gsub("---\n", "")
-        else
-          output = YAML.dump(shard.as_h.merge(compiledDeps)).gsub("---\n", "")
-        end
+        inserted = options.dev? ? shard.as_a : shard.as_h.merge(compiledDeps)
 
-        puts output
-        File.write(options.debug? ? "./shard.test.yml" : "./shard.yml", output)
+        output = YAML.dump(inserted).gsub("---\n", "").split("\n")
+        output = output.insert(2, "").insert(5, "")
+        output = output.join("\n")
+
+        File.write(file, output)
+        puts shardFile if options.debug?
         puts "\n"
 
-        Install.run unless options.debug?
+        puts "Done."
+        Install.run unless options.debug? || options.noinstall?
       end
     end
 

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -14,7 +14,7 @@ module SharnCLI
     # Just some crazy intro
     sleep(1)
     puts "Sharn".colorize.fore(:light_gray)
-    sleep(3)
+    sleep(1)
 
     class Help
       header "Additional commands for the Shards dependency manager."

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -102,28 +102,28 @@ module SharnCLI
         File.write(file, output)
 
         puts "\nDone."
-    class Rm < Packager
-        Install.run unless options.debug? || options.noinstall?
+        # Install.run unless options.debug? || options.noinstall?
       end
     end
 
-    #   def run
-    #     depType = options.dev? ? "development_dependencies" : "dependencies"
-    #     file = options.debug? ? "shard.test.yml" : "shard.yml"
-    #     puts "File detected: #{file}" if options.debug?
-    #     shardFile = File.read(file)
-    #     shard = YAML.parse(shardFile)
-    #     deps = YAML.parse(shard.as_h[depType].to_yaml).as_h || {} of String => Hash(String, String)
-    #     newDeps = {} of String => Hash(String, String)
-    #     output = YAML.dump(shard.as_h.merge({depType => newDeps})).gsub("---\n", "")
-    #     puts output if options.debug?
-
-    #     File.write(options.debug? ? "./shard.test.yml" : "./shard.yml", output)
-    #     puts "\n"
-
-    #     Install.run unless options.debug? || options.noinstall?
-    #   end
-    # end
+    class Rm < Packager
+      def run
+        depType = options.dev? ? "development_dependencies" : "dependencies"
+        file = options.debug? ? "shard.test.yml" : "shard.yml"
+        puts "File detected: #{file}" if options.debug?
+        shardFile = File.read(file)
+        shard = YAML.parse(shardFile)
+        deps = YAML.parse(shard.as_h[depType].to_yaml).as_h || {} of String => Hash(String, String)
+        newDeps = {} of String => Hash(String, String)
+        newDeps = deps.reject(args.packages)
+        compiledDeps = {depType => newDeps}
+        output = YAML.dump(shard.as_h.merge(compiledDeps)).gsub("---\n", "")
+        puts output if options.debug?
+        File.write(options.debug? ? "./shard.test.yml" : "./shard.yml", output)
+        puts "\n"
+        Install.run unless options.debug? || options.noinstall?
+      end
+    end
 
     class Inspect < Cli::Command
       class Options

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -97,10 +97,8 @@ module SharnCLI
         output = output.join("\n")
 
         File.write(file, output)
-        puts shardFile if options.debug?
-        puts "\n"
 
-        puts "Done."
+        puts "\nDone."
         Install.run unless options.debug? || options.noinstall?
       end
     end

--- a/src/sharn.cr
+++ b/src/sharn.cr
@@ -49,7 +49,7 @@ module SharnCLI
         args.packages.map do |pkgs|
           regex = Regex.new("^((github|gitlab|bitbucket):)?((.+):)?([^/]+)\/([^#]+)(#(.+))?([^@]+)?(@(.+))?$")
 
-          if match = regex.match(pkgs).not_nil!.to_a
+          if match = pkgs.match(regex).not_nil!.to_a
             platform = match[2] || "github"
             origin = match[4]
             owner = match[5]

--- a/src/sharn/version.cr
+++ b/src/sharn/version.cr
@@ -1,3 +1,3 @@
 module Sharn
-  VERSION = "0.1.17"
+  VERSION = "0.1.18"
 end

--- a/src/sharn/version.cr
+++ b/src/sharn/version.cr
@@ -1,3 +1,3 @@
 module Sharn
-  VERSION = "0.1.0"
+  VERSION = "0.1.17"
 end


### PR DESCRIPTION
Fixed remove command by shortening the command to simply `rm`.
Don't know the reason why it fails to compile but it's definitely due to the naming conflicts.

Also, shell outputs from install were removed (for now) to look for other ways on how to output directly from shards without leaving the cli.